### PR TITLE
Base python image

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,4 @@
+FROM socrata/base
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python python-dev python-pip

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,13 @@
+socrata/python
+===============
+
+socrata/base image with python 2.7 and pip installed
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/python` in a Dockerfile, nonetheless, you can run a java container as follows:
+
+    $ docker pull socrata/python
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/python python


### PR DESCRIPTION
Alrighty ops team.   Between what I read from the comments on Nick's PR,  what other base python images pull in and what I envision as a base python image, this is what I'm suggesting for our base python image.

I'm uncertain of one thing though:  should I use the 'python' namespace, or should this be named 'python2' or 'python2.7'?

This builds and runs fine locally.